### PR TITLE
Update Go plugin to latest

### DIFF
--- a/getting_started_go/plugins/BUILD
+++ b/getting_started_go/plugins/BUILD
@@ -1,6 +1,6 @@
 plugin_repo(
   name = "go",
-  revision = "v1.7.6",
+  revision = "v1.22.0",
   plugin = "go-rules",
   owner = "please-build",
 )


### PR DESCRIPTION
(1) this is ancient and I'm not sure if it fully works with the latest Go version
(2) more importantly we've had this error reported:
```
Build stopped after 490ms. 1 target failed:
    //third_party/go:testify
plz-out/gen/go/build_defs/go.build_defs:1233:12: error: Values of env must be strings, found none at key CGO_ENABLED

    repo = build_rule(
           ^
```
With this change it behaves as expected:
```
$ plz query deps //src/greetings:greetings_test 
//third_party/go:testify
  ///third_party/go/github.com_stretchr_testify//:installs
    ///third_party/go/github.com_stretchr_testify//assert:assert
      //third_party/go:toolchain
      ///go//tools:please_go
      ///third_party/go/github.com_davecgh_go-spew//spew:spew
      ///third_party/go/github.com_pmezard_go-difflib//difflib:difflib
    ///third_party/go/github.com_stretchr_testify//require:require
```